### PR TITLE
Optimize CI and fix violations

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -23,7 +23,12 @@ FileUtils.chdir APP_ROOT do
   # end
 
   puts "\n== Preparing database =="
-  system! "bin/rails db:prepare db:seed"
+  system! "bin/rails db:prepare"
+
+  unless ENV["CI"]
+    puts "\n== Seeding database =="
+    system! "bin/rails db:seed"
+  end
 
   puts "\n== Removing old logs and tempfiles =="
   system! "bin/rails log:clear tmp:clear"

--- a/test/factories.rb
+++ b/test/factories.rb
@@ -27,7 +27,7 @@ FactoryBot.define do
     copyright { "© 2022 Giant Robots Smashing Into Other Giant Robots" }
     description { "a podcast by thoughtbot" }
     episode_type { "episodic" }
-    keywords { ["design", "development", "product" ] }
+    keywords { ["design", "development", "product"] }
     language { "en-us" }
     published_at { 1.day.ago }
     subtitle { "it's a good listen" }


### PR DESCRIPTION
This commit optimizes the CI script used on GitHub actions by skipping
seeding the database. This is because the setup script
seeds the database from data over the network, resulting in [failures]
due to long build times.

[failures]: https://github.com/thoughtbot/botcasts/actions/runs/3357666998/jobs/5563641602
