### PR TITLE
Build assets during setup

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -35,6 +35,9 @@ FileUtils.chdir APP_ROOT do
   puts "\n== Removing old logs and tempfiles =="
   system! "bin/rails log:clear tmp:clear"
 
+  puts "\n== Setup test environment =="
+  system! "bin/rails test:prepare"
+
   puts "\n== Restarting application server =="
   system! "bin/rails restart"
 end


### PR DESCRIPTION
There appears to be a [bug][1] with tailwindcss-rails, or possibly
Rails, that is affecting how assets are precompiled on a cloned
repository.

Prior to this commit, we would get the following error after cloning the
repo and running the test suite:

```text
ActionView::Template::Error: The asset 'tailwind.css' was not found in
the load path.
```
One solution is to run `test:prepare` in the setup script which will
generate the assets. There is an [open pull request][2] against Rails
that would introduce this change based on [similar feedback][3]

[1]: https://github.com/rails/tailwindcss-rails/issues/158
[2]: https://github.com/rails/rails/pull/47719
[3]: https://github.com/rails/rails/pull/47210#issuecomment-1476420481
