### PR TITLE
Update Tutorial Assistant on setup

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -22,6 +22,8 @@ FileUtils.chdir APP_ROOT do
   #   FileUtils.cp "config/database.yml.sample", "config/database.yml"
   # end
 
+  puts "\n== Installing Tutorial Assistant =="
+  FileUtils.remove_dir("ta", force: true) if Dir.exist?("ta")
   system! "git clone https://github.com/thoughtbot/tutorial-assistant ta/ > /dev/null 2>&1 || true"
 
   puts "\n== Preparing database =="


### PR DESCRIPTION
Prior to this commit, we weren't updating Tutorial Assistant on
subsequent runs of `./bin/setup`. This was a problem because we weren't
pulling in fresh changes from the repository.

Closes #17
