### PR TITLE
Update README with VIPS library installation step

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,18 +7,15 @@ it using [Hotwire][].
 
 [Hotwire]: https://hotwired.dev
 
-## ⚙️  Setup
+## Requirements
+
+- Ruby `3.3.0`
+- [libvips](https://www.libvips.org/install.html)
+
+## ⚙️ Setup
 
 If this is your first time running the application, run `./bin/setup` to
 install dependencies and seed the database.
-
-In case you get the error message saying:
-```shell
-checking for vips... no
-VIPS is not installed.
-See https://www.libvips.org/install.html for install instructions.
-```
-visit the [VIPS library](https://www.libvips.org/install.html) installation page and follow the instructions depending on your operating system.
 
 ## 🏗 Running the application
 


### PR DESCRIPTION
The setup section seems to miss this step.
When following the setup instructions, you can get an error message in case you have no VIPS library installed yet.